### PR TITLE
Remove duplicate PCRE2 archive download

### DIFF
--- a/00-clone-repos.sh
+++ b/00-clone-repos.sh
@@ -59,9 +59,6 @@ download_tar "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.4
 download_tar "https://download.gnome.org/sources/glib/2.76/glib-2.76.3.tar.xz" \
   "$SRC/glib" \
   "c0be444e403d7c3184d1f394f89f0b644710b5e9331b54fa4e8b5037813ad32a"
-download_tar "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.42/pcre2-10.42.tar.bz2" \
-    "$SRC/pcre2" \
-    "8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840"
 download_tar https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2 \
     "$SRC/boost" \
     "6478edfe2f3305127cffe8caf73ea0176c53769f4bf1585be237eb30798c3b8e"


### PR DESCRIPTION
The PCRE2 archive is downloaded twice (or more correctly downloaded, extracted, and then extracted again). This pull request fixes that.